### PR TITLE
Only run `jade:dev` (not `jade:prod`)

### DIFF
--- a/grunt/contrib-watch.coffee
+++ b/grunt/contrib-watch.coffee
@@ -27,7 +27,7 @@ module.exports = (grunt) ->
         'assets/partial/**/*.jade'
       ]
       tasks: [
-        'jade'
+        'jade:dev'
       ]
       options:
         livereload: true


### PR DESCRIPTION
The `.jade` files are being compiled twice in development (both in pretty-print and not pretty-printed format).
