### PR TITLE
Only compile changed CoffeeScript files

### DIFF
--- a/grunt/contrib-watch.coffee
+++ b/grunt/contrib-watch.coffee
@@ -7,7 +7,6 @@ module.exports = (grunt) ->
       tasks: [
         'coffeelint'
         'coffee:dev'
-        'docco'
       ]
       options:
         livereload: true
@@ -31,5 +30,25 @@ module.exports = (grunt) ->
       ]
       options:
         livereload: true
+        
+  changedFiles = []
+  onChange = grunt.util._.debounce ->
+    changedCoffeeFiles = []
+
+    for filePath in changedFiles
+      fileExtension = filePath.split('.').pop()
+      if fileExtension is 'coffee'
+        changedCoffeeFiles.push filePath
+
+    if changedCoffeeFiles.length
+      grunt.config 'coffee.dev.src', changedCoffeeFiles
+      grunt.config 'coffeelint.all', changedCoffeeFiles
+    
+    changedFiles = []
+  , 200
+
+  grunt.event.on 'watch', (action, filepath) ->
+    changedFiles.push filepath
+    onChange()
 
   grunt.loadNpmTasks 'grunt-contrib-watch'

--- a/grunt/contrib-watch.coffee
+++ b/grunt/contrib-watch.coffee
@@ -10,6 +10,7 @@ module.exports = (grunt) ->
       ]
       options:
         livereload: true
+        spawn: false
     compass:
       files: [
         '<%= compass.dev.options.sassDir %>/**/*.sass'


### PR DESCRIPTION
See #7 

I've removed Docco because it doesn't seem to work with `spawn: false`. This works well for me and it's lightening-quick but it does feel a bit hacky. You may want to consider something a bit nicer like grunt-newer instead: https://github.com/tschaub/grunt-newer
